### PR TITLE
When informing of a regex syntax do it with required separators in-place

### DIFF
--- a/content/search-github/github-code-search/understanding-github-code-search-syntax.md
+++ b/content/search-github/github-code-search/understanding-github-code-search-syntax.md
@@ -317,4 +317,4 @@ If code search guesses wrong, you can always get the search you wanted by using 
 
 ## Case sensitivity
 
-By default, code search is case-insensitive. Searching for `True` will include results for _uppercase_ `TRUE` and _lowercase_ `true`. You can do case-sensitive searches by using a regular expression with case insensitivity turned off, for example `(?-i)True`.
+By default, code search is case-insensitive. Searching for `True` will include results for _uppercase_ `TRUE` and _lowercase_ `true`. You can do case-sensitive searches by using a regular expression with case insensitivity turned off, for example `/(?-i)True/`.


### PR DESCRIPTION
If we inform the user about how to make a case sensitive search using a regex syntax, do it with the regex delimitators in place, so the user:

- Don't gets an error when copying and pasting the regex syntax to the github code search textbox. Error meaning it didn't find results because it lacks the regex slash separators.

- Avoid the user to have to also find in the documentation how to enter a regex in the code search textbox. Have to find out it needs to use the slash separators.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Because a user checking docs of GitHub code search syntax to know how to search with case-sensitiveness enabled, would have to do so in two separate places (one where the required regex syntax is informed (i.e. `(?-i)`) and when pasting that and see it does not work, he would then have to find again in the documentation how a regex syntax is inputted (i.e. using two slash separators `/(?-i)/`).

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
